### PR TITLE
case-insensitive syntax

### DIFF
--- a/src/TurnerSoftware.RobotsExclusionTools/RobotsFileParser.cs
+++ b/src/TurnerSoftware.RobotsExclusionTools/RobotsFileParser.cs
@@ -58,10 +58,6 @@ namespace TurnerSoftware.RobotsExclusionTools
 				{
 					return RobotsFile.AllowAllRobots(baseUri);
 				}
-				else if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
-				{
-					return RobotsFile.DenyAllRobots(baseUri);
-				}
 				else if ((int)response.StatusCode >= 200 && (int)response.StatusCode < 300)
 				{
 					using (var stream = await response.Content.ReadAsStreamAsync())

--- a/src/TurnerSoftware.RobotsExclusionTools/Tokenization/TokenParsers/RobotsEntryTokenParser.cs
+++ b/src/TurnerSoftware.RobotsExclusionTools/Tokenization/TokenParsers/RobotsEntryTokenParser.cs
@@ -37,45 +37,45 @@ namespace TurnerSoftware.RobotsExclusionTools.Tokenization.TokenParsers
 			var result = new List<SiteAccessEntry>();
 			var parseState = new SiteAccessParseState();
 			var valueSteppingTokens = new[] { TokenType.FieldValueDelimiter };
-			var expectedFields = new[] { "User-agent", "Allow", "Disallow", "Crawl-delay" };
+			var expectedFields = new[] { "user-agent", "allow", "disallow", "crawl-delay" };
 
 			using (var enumerator = tokens.GetEnumerator())
 			{
 				var lastFieldValue = string.Empty;
 				while (enumerator.MoveTo(TokenType.Field))
 				{
-					var fieldCurrent = enumerator.Current;
+					var fieldCurrent = enumerator.Current.Value.ToLowerInvariant();
 
-					if (!expectedFields.Contains(fieldCurrent.Value))
+					if (!expectedFields.Contains(fieldCurrent))
 					{
 						continue;
 					}
 
 					//Reset the state when we have encountered a new "User-agent" field not immediately after another
-					if (lastFieldValue != string.Empty && lastFieldValue != "User-agent" && fieldCurrent.Value == "User-agent")
+					if (lastFieldValue != string.Empty && lastFieldValue != "user-agent" && fieldCurrent == "user-agent")
 					{
 						result.Add(parseState.AsEntry());
 						parseState.Reset();
 					}
 					
 					//When we have seen a field for the first time that isn't a User-agent, default to all User-agents
-					if (lastFieldValue == string.Empty && fieldCurrent.Value != "User-agent")
+					if (lastFieldValue == string.Empty && fieldCurrent != "user-agent")
 					{
 						parseState.UserAgents.Add("*");
 					}
 
-					lastFieldValue = fieldCurrent.Value;
+					lastFieldValue = fieldCurrent;
 
-					if (fieldCurrent.Value == "User-agent")
+					if (fieldCurrent == "user-agent")
 					{
 						if (enumerator.StepOverTo(TokenType.Value, valueSteppingTokens))
 						{
 							parseState.UserAgents.Add(enumerator.Current.Value);
 						}
 					}
-					else if (fieldCurrent.Value == "Allow" || fieldCurrent.Value == "Disallow")
+					else if (fieldCurrent == "allow" || fieldCurrent == "disallow")
 					{
-						var pathRule = fieldCurrent.Value == "Disallow" ? PathRuleType.Disallow : PathRuleType.Allow;
+						var pathRule = fieldCurrent == "disallow" ? PathRuleType.Disallow : PathRuleType.Allow;
 						var pathValue = string.Empty;
 
 						if (enumerator.StepOverTo(TokenType.Value, valueSteppingTokens))
@@ -95,7 +95,7 @@ namespace TurnerSoftware.RobotsExclusionTools.Tokenization.TokenParsers
 							Path = pathValue
 						});
 					}
-					else if (fieldCurrent.Value == "Crawl-delay")
+					else if (fieldCurrent == "crawl-delay")
 					{
 						if (enumerator.StepOverTo(TokenType.Value, valueSteppingTokens))
 						{


### PR DESCRIPTION
I ran into an issue where poorly formed syntax in a Robots.txt file produced incorrect behavior. The [Robots.txt at the NYTimes](https://www.nytimes.com/robots.txt) has `User-Agent` fields (with an uppercase `A`). The parser ignored the lines with incorrect syntax but included the rules in the list for the previously defined agent. In this case, it was including the rules meant for `omgili` and `omgilibot` in the rules meant for `*`.

I changed all the expected fields to lowercase along with the comparison values in `RobotsEntryTokenParser.GetSiteAccessEntries`.

Not sure how common this is or if my fix is appropriate but it seems to work in this case.

Perhaps a better fix would be to just ignore incorrect fields rather than include them in the previous agent's rules.