### PR TITLE
Allow control over the Robots.txt file access rules

### DIFF
--- a/src/TurnerSoftware.RobotsExclusionTools/IRobotsFileParser.cs
+++ b/src/TurnerSoftware.RobotsExclusionTools/IRobotsFileParser.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,8 +7,35 @@ namespace TurnerSoftware.RobotsExclusionTools
 {
 	public interface IRobotsFileParser
 	{
+		/// <summary>
+		/// Creates a <see cref="RobotsFile"/> for the provided <paramref name="robotsText"/> and using the <paramref name="baseUri"/>.
+		/// </summary>
+		/// <param name="robotsText"></param>
+		/// <param name="baseUri"></param>
+		/// <returns></returns>
 		RobotsFile FromString(string robotsText, Uri baseUri);
+		/// <summary>
+		/// Creates a <see cref="RobotsFile"/> for the provided <paramref name="robotsUri"/> and using the <see cref="RobotsFileAccessRules.NoRobotsRfc"/> access rules.
+		/// </summary>
+		/// <param name="robotsUri"></param>
+		/// <param name="cancellationToken"></param>
+		/// <returns></returns>
 		Task<RobotsFile> FromUriAsync(Uri robotsUri, CancellationToken cancellationToken = default);
+		/// <summary>
+		/// Creates a <see cref="RobotsFile"/> for the provided <paramref name="robotsUri"/> and using the specified <paramref name="accessRules"/>.
+		/// </summary>
+		/// <param name="robotsUri"></param>
+		/// <param name="accessRules"></param>
+		/// <param name="cancellationToken"></param>
+		/// <returns></returns>
+		Task<RobotsFile> FromUriAsync(Uri robotsUri, RobotsFileAccessRules robotsFileAccessRules, CancellationToken cancellationToken = default);
+		/// <summary>
+		/// Creates a <see cref="RobotsFile"/> from the data in the <paramref name="stream"/> and using the <paramref name="baseUri"/>.
+		/// </summary>
+		/// <param name="stream"></param>
+		/// <param name="baseUri"></param>
+		/// <param name="cancellationToken"></param>
+		/// <returns></returns>
 		Task<RobotsFile> FromStreamAsync(Stream stream, Uri baseUri, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/TurnerSoftware.RobotsExclusionTools/RobotsFile.cs
+++ b/src/TurnerSoftware.RobotsExclusionTools/RobotsFile.cs
@@ -18,6 +18,11 @@ namespace TurnerSoftware.RobotsExclusionTools
 			BaseUri = baseUri;
 		}
 
+		internal static RobotsFile ConditionalRobots(Uri baseUri, bool condition)
+		{
+			return condition ? AllowAllRobots(baseUri) : DenyAllRobots(baseUri);
+		}
+
 		public static RobotsFile AllowAllRobots(Uri baseUri)
 		{
 			return new RobotsFile(baseUri);

--- a/src/TurnerSoftware.RobotsExclusionTools/RobotsFileAccessRules.cs
+++ b/src/TurnerSoftware.RobotsExclusionTools/RobotsFileAccessRules.cs
@@ -1,0 +1,40 @@
+﻿namespace TurnerSoftware.RobotsExclusionTools
+{
+	public struct RobotsFileAccessRules
+	{
+		/// <summary>
+		/// Controls whether a 401 "Unauthorized" error while accessing the Robots.txt file means unrestricted access to the site.
+		/// </summary>
+		public bool AllowAllWhen401Unauthorized { get; set; }
+		/// <summary>
+		/// Controls whether a 403 "Forbidden" error while accessing the Robots.txt file means unrestricted access to the site.
+		/// </summary>
+		public bool AllowAllWhen403Forbidden { get; set; }
+		/// <summary>
+		/// Controls whether a 404 "Not Found" while accessing the Robots.txt file means unrestricted access to the site.
+		/// </summary>
+		public bool AllowAllWhen404NotFound { get; set; }
+
+		/// <summary>
+		/// Based on the <a href="http://www.robotstxt.org/norobots-rfc.txt">NoRobots RFC rules (section 3.1)</a>
+		/// </summary>
+		public static readonly RobotsFileAccessRules NoRobotsRfc = new()
+		{
+			AllowAllWhen404NotFound = true
+		};
+
+		/// <summary>
+		/// Based on the <a href="https://developers.google.com/search/docs/advanced/robots/robots_txt#handling-http-result-codes">rules used by Google</a>.
+		/// </summary>
+		/// <remarks>
+		/// Requests that return 401 or 403 allow unrestricted access.
+		/// Like the NoRobots RFC, 404 errors are also unrestricted.
+		/// </remarks>
+		public static readonly RobotsFileAccessRules LikeGoogle = new()
+		{
+			AllowAllWhen401Unauthorized = true,
+			AllowAllWhen403Forbidden = true,
+			AllowAllWhen404NotFound = true
+		};
+	}
+}


### PR DESCRIPTION
This allows controlling the behaviour of 401, 403 and 404 requests.