### PR TITLE
Add netstandard2.1 target

### DIFF
--- a/src/TurnerSoftware.RobotsExclusionTools/TurnerSoftware.RobotsExclusionTools.csproj
+++ b/src/TurnerSoftware.RobotsExclusionTools/TurnerSoftware.RobotsExclusionTools.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AssemblyName>TurnerSoftware.RobotsExclusionTools</AssemblyName>
     <Description>Robots.txt parsing and querying utility</Description>
     <PackageTags>$(PackageBaseTags)</PackageTags>


### PR DESCRIPTION
Hi @Turnerj 

Just noticed that this package seems to be pulling a lot of dependencies on our build, and probably because it is only targeting netstandard2.0. If you could add multi-targeting, this should fix it :)

Cheers and thanks for the work!
